### PR TITLE
Add a simple Mu styled coming soon page for mu-kotlin

### DIFF
--- a/_includes/_mu-coming-soon.html
+++ b/_includes/_mu-coming-soon.html
@@ -1,0 +1,12 @@
+<header id="masthead">
+    <div class="container">
+        <div class="masthead-content">
+             <div class="masthead-text">
+                 <h2>Coming soon!</h2>
+             </div>
+             <div class="masthead-brand">
+                 <img src="/img/mu-masthead-image.svg" alt="">
+             </div>
+        </div>
+    </div>
+</header>

--- a/_layouts/coming-soon.html
+++ b/_layouts/coming-soon.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    {% include _mu-head.html %}
+    <body>
+    {% include _mu-coming-soon.html %}
+    {% include _mu-main.html %}
+    {% include _mu-footer.html %}
+    </body>
+</html>

--- a/mu-kotlin/index.md
+++ b/mu-kotlin/index.md
@@ -1,0 +1,3 @@
+---
+layout: coming-soon
+---


### PR DESCRIPTION
* Add a simple Mu styled coming soon page for mu-kotlin

![screenshot_2019-01-16 mu](https://user-images.githubusercontent.com/7753447/51240428-f1ce1f00-197b-11e9-974b-dde55813bad9.png)

This closes #8 
