### PR TITLE
Remove mu-haskell placeholder page

### DIFF
--- a/mu-haskell/index.md
+++ b/mu-haskell/index.md
@@ -1,4 +1,0 @@
----
-layout: coming-soon
-permalink: mu-haskell/
----


### PR DESCRIPTION
This PR removes the Mu Haskell placeholder page in order to have its own proper site built from its repo, which is coming today :rocket:.